### PR TITLE
feat(package): support useContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Integrate user-agent detection in an idiomatic React way.
 
 `yarn add @quentin-sommer/react-useragent` or `npm i -s @quentin-sommer/react-useragent`
 
-For React 15 (old context) use the `2.x` version 
+For React 15 (old context) use the `2.x` version
 
 ```
 // React 15
@@ -21,13 +21,13 @@ For React 15 (old context) use the `2.x` version
 
 Imagine being able to render magnificent, deep links, beautiful download buttons for your app. Well, Now you can.
 
-``` js
+```js
 <div>
   <UserAgent ios>
-    <BeautifulIOSButton/>
+    <BeautifulIOSButton />
   </UserAgent>
   <UserAgent windows>
-    <BeautifulWindowsButton/>
+    <BeautifulWindowsButton />
   </UserAgent>
 </div>
 ```
@@ -40,62 +40,59 @@ react-useragent provides useful shortcuts but you can always use an escape hatch
 ## Usage
 
 First you need to wrap your App in a `<UserAgentProvider>` tag.
-You also need to pass a user agent string to `<UserAgentProvider>`. 
+You also need to pass a user agent string to `<UserAgentProvider>`.
 On the browser that would be `window.navigator.userAgent`.
 
 react-useragent works in **server side rendering** as well, just pass it the request useragent string. On express that would be `req.headers['user-agent']`.
 
-``` js
+```js
 import {UserAgentProvider} from '@quentin-sommer/react-useragent'
 
-const App = (props) => (
-    <UserAgentProvider ua={window.navigator.userAgent}>
-        <div>
-        {/* rest of your App */}
-        </div>
-    </UserAgentProvider>
+const App = props => (
+  <UserAgentProvider ua={window.navigator.userAgent}>
+    <div>{/* rest of your App */}</div>
+  </UserAgentProvider>
 )
-
 ```
 
 Then use the `<UserAgent>` component.
 
-
 react-useragent expose some props, these are optimized and using them will be faster than directly accessing the `UAParser.js` library.
 
-
 Available props for `<UserAgent>`
-* computer
-* windows
-* linux
-* mac
-* mobile
-* tablet
-* android
-* ios 
-* firefox
-* chrome
-* edge
-* safari
+
+- computer
+- windows
+- linux
+- mac
+- mobile
+- tablet
+- android
+- ios
+- firefox
+- chrome
+- edge
+- safari
 
 Theses props are cumulable : `<UserAgent firefox mobile>` will match both firefox browser and mobile systems.
 
-``` js
+```js
 import {UserAgentProvider, UserAgent} from '@quentin-sommer/react-useragent'
 
-const App = (props) => (
-    <UserAgentProvider ua={window.navigator.userAgent}>
-        <div>
-          <UserAgent mobile>
-            <p>This will only be rendered on mobile</p>
-          </UserAgent>
-        </div>
-    </UserAgentProvider>
+const App = props => (
+  <UserAgentProvider ua={window.navigator.userAgent}>
+    <div>
+      <UserAgent mobile>
+        <p>This will only be rendered on mobile</p>
+      </UserAgent>
+    </div>
+  </UserAgentProvider>
 )
 ```
 
 You can also use this alternative API if you find it more convenient
-``` js
+
+```js
 <UserAgent mobile>
     {uaIsMobile => (
         {uaIsMobile && <p>This will ONLY be rendered on mobile</p>}
@@ -105,14 +102,27 @@ You can also use this alternative API if you find it more convenient
 ```
 
 For full power you can always access the underlying parser with the `returnFullParser` prop
-``` js
+
+```js
 <UserAgent returnFullParser>
-    {parser => (
-      <p>I see you, {parser.getOS().name} {parser.getCPU().architecture}</p>
-    )}
+  {parser => (
+    <p>
+      I see you, {parser.getOS().name} {parser.getCPU().architecture}
+    </p>
+  )}
 </UserAgent>
 ```
 
-For more example see the demo app source [here](https://github.com/quentin-sommer/react-useragent/blob/master/demo/src/index.js)
+You can also use the library with the `useContext` hook
+
+```js
+import {UAContext} from '@quentin-sommer/react-useragent'
+const UsingContextHook = () => {
+  const {uaResults, parser} = useContext(UAContext)
+  return parser.getOS().name
+}
+```
+
+For more example see the demo app source [here](https://github.com/quentin-sommer/react-useragent/blob/master/example/index.tsx)
 
 If you have any questions don't hesitate to say hi on [Twitter](https://twitter.com/quentin_smr)

--- a/example/UsingContextHook.tsx
+++ b/example/UsingContextHook.tsx
@@ -1,0 +1,9 @@
+import React, {useContext} from 'react'
+import {UAContext} from '../src'
+
+const UsingContextHook = () => {
+  const {uaResults, parser} = useContext(UAContext)
+  return parser.getOS().name
+}
+
+export default UsingContextHook

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -2,10 +2,11 @@ import 'react-app-polyfill/ie11'
 import * as React from 'react'
 import {render} from 'react-dom'
 
-import {UserAgentProvider, UserAgent} from '../src'
+import {UserAgentProvider, UserAgent, UAContext} from '../src'
 import AndroidButton from './AndroidButton'
 import IOSButton from './IOSButton'
 import GitHubCorner from './GitHubCorner'
+import UsingContextHook from './UsingContextHook'
 
 class Demo extends React.Component {
   render() {
@@ -17,7 +18,7 @@ class Demo extends React.Component {
             <h1>react-useragent</h1>
             <p>
               view the source code{' '}
-              <a href="https://github.com/quentin-sommer/react-useragent/blob/master/demo/src/index.js">
+              <a href="https://github.com/quentin-sommer/react-useragent/blob/master/example/index.tsx">
                 here
               </a>
             </p>
@@ -87,16 +88,18 @@ class Demo extends React.Component {
                   I see you... {parser.getOS().name}{' '}
                   {parser.getCPU().architecture}
                   {/*
-                  {console.log(parser)}
-                  {console.log('getBrowser', parser.getBrowser())}
-                  {console.log('getCPU', parser.getCPU())}
-                  {console.log('getDevice', parser.getDevice())}
-                  {console.log('getEngine', parser.getEngine())}
-                  {console.log('getOS', parser.getOS())}
-                  */}
+                {console.log(parser)}
+                {console.log('getBrowser', parser.getBrowser())}
+                {console.log('getCPU', parser.getCPU())}
+                {console.log('getDevice', parser.getDevice())}
+                {console.log('getEngine', parser.getEngine())}
+                {console.log('getOS', parser.getOS())}
+                */}
                 </h1>
               )}
             </UserAgent>
+            {/* Or if you want to use it with useContext */}
+            <UsingContextHook />
           </div>
         </UserAgentProvider>
       </div>

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -21,7 +21,15 @@ type Props = {
   ua: string
 }
 
-export const UAContext = React.createContext({uaResults: {}, parser: {}})
+type ContextProps = {
+  parser: UAParser | {}
+  uaResults: UAResults | {}
+}
+
+export const UAContext = React.createContext<ContextProps>({
+  uaResults: {},
+  parser: {},
+})
 
 class UAProvider extends React.Component<Props> {
   uaParser: UAParser

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,2 @@
-import UserAgentProvider from './Provider'
-import UserAgent from './UserAgent'
-
-export {UserAgentProvider, UserAgent}
+export {default as UserAgent} from './UserAgent'
+export {default as UserAgentProvider, UAContext} from './Provider'

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, {useContext} from 'react'
 import {render, unmountComponentAtNode} from 'react-dom'
-import {UserAgent, UserAgentProvider} from '../src'
+import {UserAgent, UserAgentProvider, UAContext} from '../src'
 import {UAParser} from 'ua-parser-js'
 
 describe('UserAgent', () => {
@@ -68,6 +68,42 @@ describe('UserAgent', () => {
       node,
       () => {
         expect(node.innerHTML).toEqual('windows')
+      }
+    )
+  })
+
+  it('Exposes UAContext to be used with useContext', () => {
+    const WithUseContext = () => {
+      const {parser} = useContext(UAContext)
+      // @ts-ignore
+      return parser.getOS().name
+    }
+    render(
+      <UserAgentProvider ua={ms10UA}>
+        <WithUseContext />
+      </UserAgentProvider>,
+      node,
+      () => {
+        expect(node.innerHTML).toEqual('Windows')
+      }
+    )
+  })
+
+  it('Exposes UAContext to be used with class contextType', () => {
+    class WithContextType extends React.Component {
+      static contextType = UAContext
+      render() {
+        // @ts-ignore
+        return this.context.parser.getOS().name
+      }
+    }
+    render(
+      <UserAgentProvider ua={ms10UA}>
+        <WithContextType />
+      </UserAgentProvider>,
+      node,
+      () => {
+        expect(node.innerHTML).toEqual('Windows')
       }
     )
   })


### PR DESCRIPTION
this would allow usage of react-useragent with `useContext ` hook

```
import React, {useContext} from 'react'
import {UAContext} from '../src'

const UsingContextHook = () => {
  const {uaResults, parser} = useContext(UAContext)
  return parser.getOS().name
}

export default UsingContextHook

```